### PR TITLE
[FIX]Music domain col 수정

### DIFF
--- a/src/main/java/com/cau/vostom/music/domain/Music.java
+++ b/src/main/java/com/cau/vostom/music/domain/Music.java
@@ -17,9 +17,7 @@ public class Music {
     @Column(name = "music_id")
     private Long id;
 
-    private String musicName;
-
-    private String singerName;
+    private String title;
 
     private String musicImage;
 
@@ -35,10 +33,9 @@ public class Music {
     @OneToMany(mappedBy = "music", cascade = {CascadeType.REMOVE})
     private List<Comment> comments = new ArrayList<>();
 
-    public static Music createMusic(String musicName, String singerName, String musicImage, String fileUrl) {
+    public static Music createMusic(String title, String musicImage, String fileUrl) {
         Music music = new Music();
-        music.musicName = musicName;
-        music.singerName = singerName;
+        music.title = title;
         music.musicImage = musicImage;
         music.fileUrl = fileUrl;
         return music;


### PR DESCRIPTION
youtube 영상 제목에서 Music Name과 SingerName이 파싱 대신
title로 수정했습니다.